### PR TITLE
Fix import_module import path for Django 1.9

### DIFF
--- a/test_addons/test_cases.py
+++ b/test_addons/test_cases.py
@@ -8,8 +8,8 @@ from django.test import LiveServerTestCase
 # inter-app imports
 
 # local imports
-from . import mixins
-from .mixins import SimpleTestCase
+import mixins
+from mixins import SimpleTestCase
 
 
 class MongoTestCase(mixins.MongoTestMixin, SimpleTestCase):

--- a/test_addons/utils.py
+++ b/test_addons/utils.py
@@ -5,7 +5,7 @@ import shutil
 # inbuild django imports
 from django.http import HttpRequest
 from django.conf import settings
-from django.utils.importlib import import_module
+from django.utils.module_loading import import_module
 
 # third-party django imports
 from mongoengine.connection import (DEFAULT_CONNECTION_NAME, _connections, get_connection,


### PR DESCRIPTION
`django.utils.importlib` was removed in Django 1.9. See https://docs.djangoproject.com/en/1.9/internals/deprecation/
