### PR TITLE
host specified

### DIFF
--- a/test_addons/mixins.py
+++ b/test_addons/mixins.py
@@ -102,7 +102,7 @@ class MongoTestMixin(object):
 
     def _setup_database(self):
         utils.disconnect() # disconnect any existing connections built in settings
-        mongoengine.connection.connect(self.MONGO_DB_SETTINGS['db'], port = self.MONGO_DB_SETTINGS['port'])
+        mongoengine.connection.connect(self.MONGO_DB_SETTINGS['db'], host = self.MONGO_DB_SETTINGS['host'], port = self.MONGO_DB_SETTINGS['port'])
 
     def _teardown_database(self):
         connection = mongoengine.connection.get_connection()

--- a/test_addons/mixins.py
+++ b/test_addons/mixins.py
@@ -226,11 +226,11 @@ class RedisTestMixin(object):
     def setUpClass(cls):
         try:
             from django_redis import get_redis_connection
-            cls.redis_connections = map(lambda connection_name: get_redis_connection(connection_name), settings.TEST_CACHES.keys())
+            cls.redis_connections = map(lambda connection_name: get_redis_connection(connection_name), settings.CACHES.keys())
         except ImportError as exc:
             raise ImportError("django_redis must be installed to use RedisTestCase. Exception details:- {0}".format(repr(exc)))
         except AttributeError as exc:
-            raise AttributeError("settings file doesn't have redis configuration defined. Define TEST_CACHES in test settings file. Exception details:- {0}".format(repr(exc)))
+            raise AttributeError("settings file doesn't have redis configuration defined. Define CACHES in test settings file. Exception details:- {0}".format(repr(exc)))
 
         super(RedisTestMixin, cls).setUpClass()
 


### PR DESCRIPTION
I have specified the host for connecting to mongo. I don't see a point why is this expecting the host in TEST_MONGO_DATABASE in a list format. The reason I have incorporated the host is because if the db host resides in some other service and there is no mongo in your current environment, testing will fail. 

To overcome this either you have to add mongodb in the requirements.txt or better alternative incorporate host (let me know the reason why you are keeping it as list while defining in the settings file).
